### PR TITLE
Remove package name as part of the main

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -102,7 +102,7 @@ module.exports = generators.Base.extend({
         test: 'testee ' + this.props.folder + '/test.html --browsers firefox --reporter Spec',
         start: 'can-serve --port 8080'
       },
-      main: _.kebabCase(this.props.name) + '/index.stache!done-autorender',
+      main: 'index.stache!done-autorender',
       files: [this.props.folder],
       keywords: this.props.keywords,
       system: {


### PR DESCRIPTION
This is for #9. The package name is not needed to be part of the main
because the npm plugin adds this already itself.