### PR TITLE
Adding generator deps to npmIgnore

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -109,7 +109,13 @@ module.exports = generators.Base.extend({
         directories: {
           lib: 'src'
         },
-        npmIgnore: ['documentjs', 'testee', 'donejs-deploy']
+        npmIgnore: [
+          'documentjs',
+          'testee',
+          'donejs-deploy',
+          'yeoman-generator',
+          'generator-donejs'
+        ]
       }
     };
 


### PR DESCRIPTION
This adds two new modules to the npmIgnore list:

* generator-donejs
* yeoman-environment

Neither are used client-side so they are safe to ignore.

Closes #14 