### PR TITLE
Fix test page's steal script

### DIFF
--- a/app/templates/test.html
+++ b/app/templates/test.html
@@ -1,4 +1,4 @@
 <title><%= name %> tests</title>
 <script>FuncUnit = { frameMode: true };</script>
-<script src="../node_modules/steal/steal.js" main="<%= name %>/test/"></script>
+<script src="node_modules/steal/steal.js" main="<%= name %>/test/"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
This fixes the main test.html page's steal script so that it looks in
the correct `node_modules/` folder, this is a regression caused by when
we moved it out of hte `src/` folder.