### PR TITLE
Re-enable bundle assets

### DIFF
--- a/app/templates/build.js
+++ b/app/templates/build.js
@@ -3,7 +3,5 @@ var stealTools = require("steal-tools");
 var buildPromise = stealTools.build({
   config: __dirname + "/package.json!npm"
 }, {
-  bundleAssets: {
-    infer: false
-  }
+  bundleAssets: true
 });


### PR DESCRIPTION
Because of
https://github.com/stealjs/steal-bundler/commit/12889819182f10797e20b525c3eff9b1e7fc831c

The problem with bootstrap's css is now fixed. So re-enabling the
`bundleAssets` option.