### PR TITLE
Update generators to use can-fixture

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -170,7 +170,8 @@ module.exports = generators.Base.extend({
         'steal-qunit',
         'steal-tools',
         'testee',
-        'donejs-deploy'
+        'donejs-deploy',
+        'can-fixture'
       ], { saveDev: true});
     }
 

--- a/app/templates/src/models/fixtures/fixtures.js
+++ b/app/templates/src/models/fixtures/fixtures.js
@@ -1,2 +1,1 @@
-import fixture from 'can-connect/fixture/';
-
+import fixture from 'can-fixture';

--- a/supermodel/templates/fixtures/model.js
+++ b/supermodel/templates/fixtures/model.js
@@ -1,4 +1,4 @@
-import fixture from 'can-connect/fixture/';
+import fixture from 'can-fixture';
 
 const store = fixture.store([{
   <%= idProp %>: 0,
@@ -17,4 +17,3 @@ fixture({
 });
 
 export default store;
-


### PR DESCRIPTION
Because one can not simply move a repository and not update the things that use it.