### PR TITLE
Add dependency on lodash.upperfirst

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   ],
   "dependencies": {
     "lodash": "^3.10.0",
+    "lodash.upperfirst": "^4.1.2",
     "q": "^1.4.1",
     "semver": "^5.1.0",
     "yeoman-generator": "^0.20.2"

--- a/supermodel/index.js
+++ b/supermodel/index.js
@@ -2,6 +2,7 @@ var generators = require('yeoman-generator');
 var path = require('path');
 var _ = require('lodash');
 var utils = require('../lib/utils');
+var upperFirst = require("lodash.upperfirst");
 
 module.exports = generators.Base.extend({
   constructor: function () {
@@ -69,7 +70,7 @@ module.exports = generators.Base.extend({
     }
 
     var options = {
-      className: _.upperFirst(_.camelCase(this.name)),
+      className: upperFirst(_.camelCase(this.name)),
       name: this.name,
       url: this.props.url,
       idProp: this.props.idProp

--- a/test/supermodel.test.js
+++ b/test/supermodel.test.js
@@ -1,0 +1,36 @@
+var assert = require('assert');
+var path = require('path');
+var helpers = require('yeoman-generator').test;
+var exec = require('child_process').exec;
+var donejsPackage = require('donejs-cli/package.json');
+var npmVersion = require('../lib/utils').npmVersion;
+var fs = require('fs-extra');
+
+function pipe(child) {
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+}
+
+describe('generator-donejs', function () {
+  it('donejs:supermodel', function (done) {
+    var tmpDir;
+
+    helpers.run(path.join(__dirname, '../supermodel'))
+      .inTmpDir(function (dir) {
+        tmpDir = dir;
+        fs.copySync(path.join( __dirname, "tests", "basics" ), dir)
+      })
+      .withOptions({
+        skipInstall: true
+      })
+      .withPrompts({
+        name: 'messages',
+        url: "/messages",
+        idProp: "id"
+      })
+      .on('end', function () {
+        assert( fs.existsSync( path.join( tmpDir, "src", "models", "messages.js" ) ), "bar.js exists" );
+        done();
+      });
+  });
+});

--- a/test/tests/basics/package.json
+++ b/test/tests/basics/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "no-directories",
+	"main": "index.js",
+	"version": "1.0.0",
+  "system": {
+    "directories": {
+      "lib": "src"
+    }
+  }
+}


### PR DESCRIPTION
This was added in lodash 4.0 and we are using 3.x. Because I don't want
to risk other breaking changes by including lodash 3.x, I'm just going
to depend on lodash.upperfirst and use it where needed. Closes #85