### PR TITLE
Adding can-ssr dependency back to plugin generator

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -179,6 +179,7 @@ module.exports = generators.Base.extend({
         'testee': getDependency('testee'),
         'generator-donejs': getDependency('generator-donejs'),
         'donejs-cli': getDependency('donejs-cli'),
+        'can-ssr': getDependency('can-ssr')
       }
     }));
 


### PR DESCRIPTION
It got removed in https://github.com/donejs/generator-donejs/commit/7cb31333b655f473156881ba16dca55e781c8342#diff-77133e49354dd4b50f49c5d8634333ddL174 but we need it to host the static files.