### PR TITLE
Update plugin-generator to use done-serve instead of can-serve

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -24,7 +24,7 @@ module.exports = generators.Base.extend({
       'readme.md',
       '_gitignore'
     ];
-    
+
     this.srcFiles = [
       'test/test.html',
       'test/test.js',
@@ -123,7 +123,7 @@ module.exports = generators.Base.extend({
         "release:major": "npm version major && npm publish",
         build: "node build.js",
         document: "documentjs",
-        develop: "can-serve --static --develop --port 8080"
+        develop: "done-serve --static --develop --port 8080"
       },
       main: "dist/cjs/" + this.props.name,
       browser: {
@@ -158,9 +158,9 @@ module.exports = generators.Base.extend({
     }
 
     this.log('Writing package.json v' + this.options.version);
-    
+
     var getDependency = function(name) {
-      return self.options.packages.dependencies[name] || 
+      return self.options.packages.dependencies[name] ||
         self.options.packages.devDependencies[name];
     };
 
@@ -179,13 +179,13 @@ module.exports = generators.Base.extend({
         'testee': getDependency('testee'),
         'generator-donejs': getDependency('generator-donejs'),
         'donejs-cli': getDependency('donejs-cli'),
-        'can-ssr': getDependency('can-ssr')
+        'done-serve': getDependency('done-serve')
       }
     }));
 
     this.fs.copy(this.templatePath('static'), this.destinationPath());
     this.fs.copy(this.templatePath('static/.*'), this.destinationPath());
-    
+
     this.mainFiles.forEach(function(name) {
       // Handle bug where npm has renamed .gitignore to .npmignore
       // https://github.com/npm/npm/issues/3763
@@ -195,7 +195,7 @@ module.exports = generators.Base.extend({
         self.props
       );
     });
-    
+
     this.srcFiles.forEach(function(name) {
       self.fs.copyTpl(
         self.templatePath(name),


### PR DESCRIPTION
Currently, when generating a plugin with the plugin generator, DoneJS 8.0 is failing when you `donejs develop`, because it is lookign for a `can-serve` that no longer exists.