### PR TITLE
Make generator installs be for version ranges

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -1,6 +1,8 @@
 var generators = require('yeoman-generator');
 var path = require('path');
 var _ = require('lodash');
+var packages = require('./packages');
+var utils = require('../lib/utils');
 
 module.exports = generators.Base.extend({
   initializing: function () {
@@ -14,7 +16,7 @@ module.exports = generators.Base.extend({
       homepage: this.pkg.homepage,
       repository: this.pkg.repository
     };
-    
+
     this.mainFiles = [
       '_gitignore',
       'license.md',
@@ -27,7 +29,7 @@ module.exports = generators.Base.extend({
 
   prompting: function () {
     var done = this.async();
-    
+
     var prompts = [{
       name: 'name',
       message: 'Project name',
@@ -77,7 +79,7 @@ module.exports = generators.Base.extend({
 
   writing: function () {
     var self = this;
-    
+
     this.fs.writeJSON('package.json', {
       name: this.props.name,
       version: '0.0.0',
@@ -102,13 +104,16 @@ module.exports = generators.Base.extend({
       },
       keywords: this.props.keywords
     });
-    
-    this.npmInstall(['yeoman-generator', 'lodash'], { 'save': true });
-    this.npmInstall(['mocha', 'jshint', 'yeoman-assert', 'yeoman-test'], { 'saveDev': true });
+
+    var deps = utils.toNpmInstallStrings(packages.dependencies);
+    var devDeps = utils.toNpmInstallStrings(packages.devDependencies);
+
+    this.npmInstall(deps, { 'save': true });
+    this.npmInstall(devDeps, { 'saveDev': true });
 
     this.fs.copy(this.templatePath('static'), this.destinationPath());
     this.fs.copy(this.templatePath('static/.*'), this.destinationPath());
-    
+
     this.mainFiles.forEach(function(name) {
       // Handle bug where npm has renamed .gitignore to .npmignore
       // https://github.com/npm/npm/issues/3763

--- a/generator/packages.js
+++ b/generator/packages.js
@@ -1,0 +1,12 @@
+module.exports = {
+  dependencies: {
+    "yeoman-generator": "^0.20.2",
+    "lodash": "^4.13.1"
+  },
+  devDependencies: {
+    "mocha": "^2.5.1",
+    "jshint": "^2.9.2",
+    "yeoman-assert": "^2.2.1",
+    "yeoman-test": "^1.4.0"
+  }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,7 +47,16 @@ exports.templatePath = function(subPath) {
     if(fs.existsSync(override)) {
       return override;
     }
-    
+
     return generators.Base.prototype.templatePath.apply(this, arguments);
   };
+};
+
+// turn an map of package to version ranges to an array of the same
+exports.toNpmInstallStrings = function(deps){
+  return Object.keys(deps).map(function(packageName){
+    var versionRange = deps[packageName];
+
+    return packageName + "@" + versionRange;
+  });
 };

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -27,4 +27,18 @@ describe('generator:utils', function() {
       });
     });
   });
+
+  describe('toNpmInstallStrings', function() {
+    it('works', function(){
+      var deps = {
+        foo: "^1.0.0",
+        bar: "~2.0.0"
+      };
+      var strings = utils.toNpmInstallStrings(deps);
+
+      assert.equal(strings.length, 2, "There are two deps");
+      assert.equal(strings[0], "foo@^1.0.0");
+      assert.equal(strings[1], "bar@~2.0.0");
+    });
+  });
 });


### PR DESCRIPTION
This fixes #130 fixing the generator generator. Creates
`generator/packages.js` which lists the dependencies and version ranges
that will be installed.