### PR TITLE
Use a simplified production steal script tag

### DIFF
--- a/app/templates/src/index.stache
+++ b/app/templates/src/index.stache
@@ -10,7 +10,7 @@
 
     {{#switch env.NODE_ENV}}
       {{#case "production"}}
-        <script src="{{joinBase 'node_modules/steal/steal.production.js'}}"  main="<%= name %>/index.stache!done-autorender"></script>
+        <script src="{{joinBase 'dist/steal.production.js'}}"></script>
       {{/case}}
       {{#default}}
         <script src="/node_modules/steal/steal.js"></script>


### PR DESCRIPTION
This simplifies the production script tag so that it uses the new
preconfigured steal.production.js that was added in Steal 1.0.

Closes #173