### PR TITLE
Update the default renderingBaseURL

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -162,7 +162,7 @@ module.exports = generators.Base.extend({
         plugins: [ 'done-css', 'done-component', 'steal-less', 'steal-stache' ],
         envs: {
           'server-production': {
-            renderingBaseURL: 'dist'
+            renderingBaseURL: '/dist'
           }
         }
       }


### PR DESCRIPTION
This fixes the default renderingBaseURL so that it works with nested
routes.

Closes #177