### PR TITLE
Use modern DefineMap/List syntax

### DIFF
--- a/supermodel/templates/model.js
+++ b/supermodel/templates/model.js
@@ -7,7 +7,7 @@ import loader from '@loader';
 const <%= className %> = DefineMap.extend({
   seal: false
 }, {
-  '<%= idProp %>': '*'
+  '<%= idProp %>': 'any'
 });
 
 const algebra = new set.Algebra(
@@ -15,7 +15,7 @@ const algebra = new set.Algebra(
 );
 
 <%= className %>.List = DefineList.extend({
-  '*': <%= className %>
+  '#': <%= className %>
 });
 
 <%= className %>.connection = superMap({

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -34,7 +34,7 @@ describe('generator-donejs:plugin', function () {
 
         child.on('exit', function (status) {
           assert.equal(status, 0, 'Got correct exit status');
-          
+
           child = exec('npm run build', {
             cwd: tmpDir
           });
@@ -89,6 +89,21 @@ describe('generator-donejs:plugin', function () {
             "steal-stache": "^3.0.5"
           }
         });
+        done();
+      });
+  });
+
+  it('fails if there are no packages', function(done) {
+    helpers.run(path.join(__dirname, '../plugin'))
+      .withOptions({
+        packages: null,
+        skipInstall: true
+      })
+      .withPrompts({
+        name: 'my-plugin'
+      })
+      .on('error', function(err){
+        assert(true, 'An error for not providing packages');
         done();
       });
   });


### PR DESCRIPTION
This uses the more modern DefineMap/List syntax of `any` to denote a
property that can be any type and `#` for the list's Map type.

Closes #214

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
