### PR TITLE
Only kebabCase invalid npm names

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -98,10 +98,18 @@ module.exports = BaseGenerator.extend({
 
       this.prompt(prompts).then(function(props) {
         this.props = _.extend(this.props, props);
-        this.props.name = _.kebabCase(this.props.name);
 
         var validationResults = validate(this.props.name);
         var isValidName = validationResults.validForNewPackages;
+
+        // Try to fix it by kebab casing.
+        // We don't do this first because kebabCase can change
+        // otherwise valid names, which is undesirable.
+        if(!isValidName) {
+          this.props.name = _.kebabCase(this.props.name);
+          validationResults = validate(this.props.name);
+          isValidName = validationResults.validForNewPackages;
+        }
 
         if(!isValidName) {
           var warnings = validationResults.warnings;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -191,6 +191,32 @@ describe('generator-donejs', function () {
       });
   });
 
+  describe('Package names', function(){
+    it('can include numbers', function(done){
+      var tmpDir;
+
+      helpers.run(path.join(__dirname, '../app'))
+        .inTmpDir(function (dir) {
+          tmpDir = dir;
+        })
+        .withOptions({
+          packages: donejsPackage.donejs,
+          skipInstall: true
+        })
+        .withPrompts({
+          name: 'hot5'
+        })
+        .on('end', function () {
+          var pkg = require(tmpDir + '/package.json');
+
+          assert.equal(pkg.name, 'hot5', 'name was not changed');
+          assert.equal(pkg.main, 'hot5/index.stache!done-autorender', 'main is correct');
+
+          done();
+        });
+    });
+  });
+
   describe('if user can\'t write to ~/yo-rc-global.json', function() {
     var globalConfigPath, globalConfigPermissions;
 


### PR DESCRIPTION
kebabCasing a package name can destroy what are otherwise valid package names. The fix is to first check if the name is valid, and if so to leave it alone. Changing only happens if the name is invalid.

Closes #225