### PR TITLE
Improve the generated plugin index.html

### DIFF
--- a/plugin/templates/README.md
+++ b/plugin/templates/README.md
@@ -1,6 +1,6 @@
 # <%= name %>
 
-[![Build Status](https://travis-ci.org/<%= githubAccount %>/<%= name %>.png?branch=master)](https://travis-ci.org/<%= githubAccount %>/<%= name %>)
+[![Build Status](https://travis-ci.org/<%= githubAccount %>/<%= name %>.svg?branch=master)](https://travis-ci.org/<%= githubAccount %>/<%= name %>)
 
 <%= description %>
 

--- a/plugin/templates/index.html
+++ b/plugin/templates/index.html
@@ -22,7 +22,7 @@
         border-radius: 2px;
         color: #222;
         margin-bottom: 1.5em;
-        overflow-x: scroll:
+        overflow-x: scroll;
         padding: 10px;
       }
 

--- a/plugin/templates/index.html
+++ b/plugin/templates/index.html
@@ -16,10 +16,11 @@
       }
       pre {
         background-color: #eee;
-        color: #222;
-        padding: 10px;
         border-radius: 2px;
+        color: #222;
         margin-bottom: 1.5em;
+        overflow-x: scroll:
+        padding: 10px;
       }
 
       header h1 {

--- a/plugin/templates/index.html
+++ b/plugin/templates/index.html
@@ -10,9 +10,9 @@
         border-top: 2px solid #CB3036;
       }
       .container {
-        max-width: 680px;
-        padding: 20px;
         margin: 20px auto;
+        max-width: 800px;
+        padding: 20px;
       }
       pre {
         background-color: #eee;
@@ -67,7 +67,7 @@
       <header>
         <div class='links'>
           <p><a href="https://github.com/<%= githubAccount %>/<%= name %>">View on Github</a></p>
-          <p><a href="https://travis-ci.org/<%= githubAccount %>/<%= name %>"><img alt='Build Status' src='https://travis-ci.org/<%= githubAccount %>/<%= name %>.png?branch=master'/></a></p>
+          <p><a href="https://travis-ci.org/<%= githubAccount %>/<%= name %>"><img alt='Build Status' src='https://travis-ci.org/<%= githubAccount %>/<%= name %>.svg?branch=master'/></a></p>
         </div>
         <h1><%= name %></h1>
         <h2><%= description %></h2>

--- a/plugin/templates/index.html
+++ b/plugin/templates/index.html
@@ -14,6 +14,9 @@
         max-width: 800px;
         padding: 20px;
       }
+      .text-right {
+        text-align: right;
+      }
       pre {
         background-color: #eee;
         border-radius: 2px;
@@ -66,8 +69,8 @@
     <div class="container">
       <header>
         <div class='links'>
-          <p><a href="https://github.com/<%= githubAccount %>/<%= name %>">View on Github</a></p>
-          <p><a href="https://travis-ci.org/<%= githubAccount %>/<%= name %>"><img alt='Build Status' src='https://travis-ci.org/<%= githubAccount %>/<%= name %>.svg?branch=master'/></a></p>
+          <p><a href="https://github.com/<%= githubAccount %>/<%= name %>">View on GitHub</a></p>
+          <p class="text-right"><a href="https://travis-ci.org/<%= githubAccount %>/<%= name %>"><img alt='Build Status' src='https://travis-ci.org/<%= githubAccount %>/<%= name %>.svg?branch=master'/></a></p>
         </div>
         <h1><%= name %></h1>
         <h2><%= description %></h2>


### PR DESCRIPTION
- The `pre` sections now scroll horizontally
- Use SVG instead of PNG for the Travis icon (and right-align it)
- Default to a greater width

Before:
<img width="759" alt="screen shot 2017-04-26 at 2 51 48 pm" src="https://cloud.githubusercontent.com/assets/10070176/25458781/2e9c52da-2a90-11e7-8225-059c974bfafb.png">

After:
<img width="665" alt="screen shot 2017-04-26 at 2 51 37 pm" src="https://cloud.githubusercontent.com/assets/10070176/25458788/352f83b0-2a90-11e7-8451-c4e92fc28fa5.png">