### PR TITLE
Speed up the DoneJS generators with yarn support

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -231,7 +231,11 @@ module.exports = BaseGenerator.extend({
   end: function () {
     if(!this.options.skipInstall) {
       var done = this.async();
-      this.spawnCommand('npm', ['--loglevel', 'error', 'install']).on('close', done);
+      if (utils.yarnInstalled) {
+        this.spawnCommand('yarn').on('close', done);
+      } else {
+        this.spawnCommand('npm', ['--loglevel', 'error', 'install']).on('close', done);
+      }
     }
   }
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var semver = require('semver');
 var cp = require('child_process');
 var isValidElementName = require('is-valid-element-name');
+var cmd = require('child_process').execSync;
 
 exports.addImport = function(filename, module, name) {
   if(fs.existsSync(filename)) {
@@ -120,4 +121,13 @@ exports.getKeywords = function (kind, keywords) {
   return keywords.sort(function (a, b) {
     return a.localeCompare(b);
   });
+};
+
+var yarnInstalled;
+try {
+  cmd('yarn bin').toString();
+  yarnInstalled = true;
+} catch (err) {
+  yarnInstalled = false;
 }
+exports.yarnInstalled = yarnInstalled;


### PR DESCRIPTION
I've added a simple utility to detect yarn and use it to install dependencies if it's installed.  This brings the install time down to 30 seconds when generating a new DoneJS app.

I haven't figured out a good way to test this.