### PR TITLE
Set "latedef" to "nofunc" in the plugin generator

### DIFF
--- a/plugin/templates/static/.jshintrc
+++ b/plugin/templates/static/.jshintrc
@@ -26,7 +26,7 @@
 	"eqeqeq": true,
 	"freeze": true,
 	"indent": 2,
-	"latedef": true,
+	"latedef": "nofunc",
 	"noarg": true,
 	"undef": true,
 	"unused": true,


### PR DESCRIPTION
This change makes the plugin generator consistent with the [generator generator](https://github.com/donejs/generator-donejs/blob/801dace37f583f967ca68d1e3109c169ffec3bd2/generator/templates/static/.jshintrc#L10).

JSHint will no longer complain about the function being “used before it was defined” in this example:

```js
work();

function work() {}
```

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
