### PR TITLE
Make algebra after the List in supermodel template

### DIFF
--- a/supermodel/templates/model.js
+++ b/supermodel/templates/model.js
@@ -10,13 +10,13 @@ const <%= className %> = DefineMap.extend({
   '<%= idProp %>': 'any'
 });
 
-const algebra = new set.Algebra(
-  set.props.id('<%= idProp %>')
-);
-
 <%= className %>.List = DefineList.extend({
   '#': <%= className %>
 });
+
+const algebra = new set.Algebra(
+  set.props.id('<%= idProp %>')
+);
 
 <%= className %>.connection = superMap({
   url: loader.serviceBaseURL + '<%= url %>',


### PR DESCRIPTION
Moves the creation of the algebra until after the List, since logically
the algebra informs how lists are handled. Closes #271

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
