### PR TITLE
Provide env.NODE_ENV as a default AppViewModel property

### DIFF
--- a/app/templates/src/app.js
+++ b/app/templates/src/app.js
@@ -3,6 +3,10 @@ import route from 'can-route';
 import 'can-route-pushstate';
 
 const AppViewModel = DefineMap.extend({
+  env: {
+    default: () => ({NODE_ENV:'development'}),
+    serialize: false
+  },
   message: {
     default: 'Hello World!',
     serialize: false


### PR DESCRIPTION
This prevents the warning that occurs with all donejs apps due to us
using this in the index.stache file.