### PR TITLE
Update generated app.js for DoneJS 3 routing

### DIFF
--- a/app/templates/src/app.js
+++ b/app/templates/src/app.js
@@ -1,21 +1,21 @@
 import { DefineMap, route, RoutePushstate } from 'can';
 import 'can-debug#?./is-dev';
 
-route.urlData = new RoutePushstate();
-
 const AppViewModel = DefineMap.extend({
   env: {
     default: () => ({NODE_ENV:'development'}),
-    serialize: false
-  },
-  message: {
-    default: 'Hello World!',
     serialize: false
   },
   title: {
     default: '<%= name %>',
     serialize: false
   }
+  routeData: {
+    default: route.data
+  }
 });
+
+route.urlData = new RoutePushstate();
+route.register("{page}", { page: "home" });
 
 export default AppViewModel;

--- a/app/templates/src/app.js
+++ b/app/templates/src/app.js
@@ -3,15 +3,13 @@ import 'can-debug#?./is-dev';
 
 const AppViewModel = DefineMap.extend({
   env: {
-    default: () => ({NODE_ENV:'development'}),
-    serialize: false
+    default: () => ({NODE_ENV:'development'})
   },
   title: {
-    default: '<%= name %>',
-    serialize: false
+    default: '<%= name %>'
   }
   routeData: {
-    default: route.data
+    default: () => route.data
   }
 });
 

--- a/app/templates/src/app.js
+++ b/app/templates/src/app.js
@@ -7,7 +7,7 @@ const AppViewModel = DefineMap.extend({
   },
   title: {
     default: '<%= name %>'
-  }
+  },
   routeData: {
     default: () => route.data
   }

--- a/app/templates/src/index.stache
+++ b/app/templates/src/index.stache
@@ -6,15 +6,12 @@
     <can-import from="~/styles.less" />
     <can-import from="~/app" export-as="viewModel" />
 
-    <h1>{{message}}</h1>
+    <h1>The <strong>{{this.routeData.page}}</strong> page</h1>
 
-    {{#switch env.NODE_ENV}}
-      {{#case "production"}}
-        <script src="{{joinBase('steal.production.js')}}"></script>
-      {{/case}}
-      {{#default}}
-        <script src="/node_modules/steal/steal.js" main></script>
-      {{/default}}
-    {{/switch}}
+    {{#eq(this.env.NODE_ENV, "production")}}
+      <script src="{{joinBase('steal.production.js')}}"></script>
+    {{else}}
+      <script src="/node_modules/steal/steal.js" main></script>
+    {{/eq}}
   </body>
 </html>

--- a/app/templates/src/index.stache
+++ b/app/templates/src/index.stache
@@ -1,10 +1,10 @@
 <html>
   <head>
-    <title>{{title}}</title>
+    <title>{{this.title}}</title>
   </head>
   <body>
     <can-import from="~/styles.less" />
-    <can-import from="~/app" export-as="viewModel" />
+    <can-import from="~/app" export-as="viewModel" route-data="routeData" />
 
     <h1>The <strong>{{this.routeData.page}}</strong> page</h1>
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "coveralls-send": "0.0.2",
     "donejs": "*",
-    "donejs-cli": "^2.0.0-pre.4",
+    "donejs-cli": "^3.0.0-pre.2",
     "fs-extra": "^0.30.0",
     "istanbul": "^0.4.2",
     "mkdirp": "^0.5.1",

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -385,24 +385,12 @@ function prepareRoutingTest(tmpDir){
   // import the copied test in test.js (note that it refers project name):
   fs.appendFileSync(path.join(tmpDir, 'src/test.js'), '\nimport "place-my-tmp/test/routing.test";\n');
 
-  // add page property to AppViewModel
-  insert(
-    path.join(tmpDir, 'src/app.js'),
-    function(a){ return a.search('message') !== -1; },
-    'page: \'string\',',
-    true
-  );
-
-  // add routing into app.js:
-  // route('/:page', {page: 'home'});
-  fs.appendFileSync(path.join(tmpDir, 'src/app.js'), '\nroute("/:page", {page: "home"});\n');
-
   // add a button for navigation into index.stache after H1:
   insert(
     path.join(tmpDir, 'src/index.stache'),
     function(a){ return a.search('<h1>') !== -1; },
     '<can-import from="can-stache-route-helpers" />' +
-    '<a id="goto-dashboard" href="{{routeUrl page=\'dashboard\'}}">Goto Dashboard</a>'
+    '<a id="goto-dashboard" href="{{routeUrl(page=\'dashboard\')}}">Goto Dashboard</a>'
   );
 }
 

--- a/test/app_tests/routing.test.js
+++ b/test/app_tests/routing.test.js
@@ -13,6 +13,6 @@ QUnit.test('App should route with hashtags', function(assert) {
 	F('#goto-dashboard').click();
 
 	F.add(function(){
-		assert.equal(F.win.location.hash, '#!/dashboard', 'location.hash should contain a hashtag');
+		assert.equal(F.win.location.hash, '#!dashboard', 'location.hash should contain a hashtag');
 	});
 });


### PR DESCRIPTION
This updates the app generator so that the routing works using
the built-in `route.data` rather than setting it.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
