### PR TITLE
Use the can-route-pushstate package

### DIFF
--- a/app/templates/src/app.js
+++ b/app/templates/src/app.js
@@ -1,5 +1,12 @@
-import { DefineMap, route, RoutePushstate } from 'can';
-import 'can-debug#?./is-dev';
+import { DefineMap, route } from 'can';
+import RoutePushstate from 'can-route-pushstate';
+import debug from 'can-debug#?is-dev';
+
+//!steal-remove-start
+if(debug) {
+	debug();
+}
+//!steal-remove-end
 
 const AppViewModel = DefineMap.extend({
   env: {

--- a/app/templates/src/app.js
+++ b/app/templates/src/app.js
@@ -1,6 +1,6 @@
 import { DefineMap, route } from 'can';
 import RoutePushstate from 'can-route-pushstate';
-import debug from 'can-debug#?is-dev';
+import debug from 'can-debug#?./is-dev';
 
 //!steal-remove-start
 if(debug) {


### PR DESCRIPTION
This uses can-route-pushstate so that we can correctly alias it in
development.html.

Fixes #289