### PR TITLE
Export the ViewModel and Component from modlets

### DIFF
--- a/app/templates/src/app.js
+++ b/app/templates/src/app.js
@@ -8,7 +8,7 @@ if(debug) {
 }
 //!steal-remove-end
 
-const AppViewModel = DefineMap.extend({
+const AppViewModel = DefineMap.extend("AppViewModel", {
   env: {
     default: () => ({NODE_ENV:'development'})
   },

--- a/component/templates/modlet/component.js
+++ b/component/templates/modlet/component.js
@@ -2,7 +2,7 @@ import { Component } from 'can';
 import './<%= name %>.less';
 import view from './<%= name %>.stache';
 
-export default Component.extend({
+export const <%= tagCase %> = Component.extend({
   tag: '<%= tag %>',
   view,
   ViewModel: {
@@ -30,3 +30,6 @@ export default Component.extend({
     }
   }
 });
+
+export default <%= tagCase %>;
+export const ViewModel = <%= tagCase %>.ViewModel;

--- a/test/component.test.js
+++ b/test/component.test.js
@@ -56,6 +56,30 @@ describe('generator-donejs', function () {
         });
     });
 
+    it('Exports the component and ViewModel in a modlet', function(done) {
+      var tmpDir;
+
+      helpers.run(path.join(__dirname, '../component'))
+        .inTmpDir(function (dir) {
+          tmpDir = dir;
+          fs.copySync(path.join( __dirname, "tests", 'basics'), dir)
+        })
+        .withOptions({
+          skipInstall: true
+        })
+        .withPrompts({
+          name: 'pages/restaurant/list',
+          tag: 'pmo-restaurant-list'
+        })
+        .on('end', function () {
+          var compFile = path.join(tmpDir, 'src', 'pages', 'restaurant', 'list', 'list.js');
+          assert.fileContent(compFile, /export const PmoRestaurantList/);
+          assert.fileContent(compFile, /export default PmoRestaurantList/);
+          assert.fileContent(compFile, /export const ViewModel = PmoRestaurantList\.ViewModel/);
+          done();
+        });
+    });
+
     it('can provide a name that includes the package name', function(done) {
       var tmpDir;
 


### PR DESCRIPTION
This makes it so that both the ViewModel and Component get exported from
modlets. The Component gets exported both as a constructor-case name
like `PmoRestaurantList` and as the default export. The ViewModel is
exported as `ViewModel`.