### PR TITLE
Use `can` plugin for steal

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -201,7 +201,7 @@ module.exports = class extends BaseGenerator {
           'node_modules/can-zone/register',
           'node_modules/steal-conditional/conditional'
         ],
-        plugins: [ 'done-css', 'done-component', 'steal-less', 'steal-stache' ],
+        plugins: [ 'done-css', 'done-component', 'steal-less', 'can' ],
         envs: {
           'server-production': {
             renderingBaseURL: '/dist'

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -164,7 +164,7 @@ describe('generator-donejs', function () {
     });
   });
 
-  it('steal-less and steal-stache are added as steal plugins', function(done) {
+  it('steal-less and can are added as steal plugins', function(done) {
     var tmpDir;
 
     helpers.run(generator)
@@ -183,7 +183,7 @@ describe('generator-donejs', function () {
         var plugins = pkg.steal.plugins;
 
         assert.ok(plugins.indexOf('steal-less') >= 0, 'plugins config should contain steal-less');
-        assert.ok(plugins.indexOf('steal-stache') >= 0, 'plugins config should contain steal-stache');
+        assert.ok(plugins.indexOf('can') >= 0, 'plugins config should contain can');
         assert.ok(plugins.indexOf('done-component') >= 0, 'plugins config should contain done-component');
         assert.ok(plugins.indexOf('done-css') >= 0, 'plugins config should contain done-css');
 


### PR DESCRIPTION
This switches to using the `can` plugin for steal. This prevents the
need for directly depending on steal-stache within donejs projects,
     which should eliminate multiple version warnings from occuring when
     upgrading canjs versions.