### PR TITLE
Handle scoped name of projects

### DIFF
--- a/plugin/templates/test.html
+++ b/plugin/templates/test.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <title><%= name %></title>
-<script src="node_modules/steal/steal.js" main="<%= name %>/test"></script>
+<script src="node_modules/steal/steal.js" main="~/<%= name %>-test"></script>
 <div id="qunit-fixture"></div>

--- a/plugin/templates/test.js
+++ b/plugin/templates/test.js
@@ -1,1 +1,0 @@
-import './<%= name %>-test';

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -154,4 +154,35 @@ describe('generator-donejs:plugin', function () {
         done();
       });
   });
+
+  it('should handle scoped package names', function (done) {
+    var tmpDir;
+
+    helpers.run(path.join(__dirname, '../plugin'))
+      .inTmpDir(function (dir) {
+        tmpDir = dir;
+      })
+      .withOptions({
+        packages: donejsPackage.donejs,
+        skipInstall: false
+      })
+      .withPrompts({
+        name: '@bitovi/my-plugin'
+      })
+      .on('end', function () {
+        var child = exec('npm test', {
+          cwd: tmpDir
+        });
+
+        pipe(child);
+
+        child.on('exit', function (status) {
+          assert.equal(status, 0, 'Got correct exit status');
+
+          assert.jsonFileContent('package.json', { name: '@bitovi/my-plugin' }, 'correct name set in package.json');
+          assert.jsonFileContent('package.json', { main: 'dist/cjs/my-plugin' }, 'correct main set in package.json');
+          done();
+        });
+      });
+  });
 });


### PR DESCRIPTION
This will keep the name in the package.json if you provide a name like "@bitovi/my-plugin" and will prompt if you are wish the package to be public which is default and will add "--access public" to the npm publish scripts.

Ref - https://github.com/donejs/donejs/issues/1176